### PR TITLE
added space, esc and arrow keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,14 @@ This web-based single-page application (SPA) is a voice-activated teleprompter, 
 You can try it live [here](https://jlecomte.github.io/voice-activated-teleprompter/dist/).
 
 **Instructions:** Once you've opened the live demo, click on the `Edit` button in the toolbar. Paste your script into the content area and click on the `Edit` button again to validate. Then, click on the `Play` button in the toolbar and start reading your script. If you need to take a break, you can click on the `Stop` button at any time, and then later resume the transcription by clicking on the `Play` button again. You can also click on individual words in your script to reset the transcription to a specific index in case you need to re-read a section of your script.
+
+**Keyboard Shortcuts:** While the teleprompter is running (not in edit mode), the following keyboard shortcuts are available:
+
+| Key | Action |
+|-----|--------|
+| `Space` | Start/stop the teleprompter |
+| `Escape` | Stop the teleprompter |
+| `Arrow Up` | Jump back 15 words |
+| `Arrow Down` | Jump forward 15 words |
+| `Arrow Left` | Jump back 5 words |
+| `Arrow Right` | Jump forward 5 words |

--- a/src/features/content/Content.tsx
+++ b/src/features/content/Content.tsx
@@ -73,6 +73,8 @@ export const Content = () => {
 
   useEffect(() => {
     const handleKeyPress = (event: KeyboardEvent) => {
+      if (status === "editing") return;
+
       const maxIndex = textElements.length - 1;
 
       if (event.code === "Escape") {

--- a/src/features/content/Content.tsx
+++ b/src/features/content/Content.tsx
@@ -20,6 +20,8 @@ import {
   selectInterimTranscriptIndex,
 } from "./contentSlice"
 
+import { startTeleprompter, stopTeleprompter } from "../../app/thunks"
+
 export const Content = () => {
   const dispatch = useAppDispatch()
 
@@ -68,6 +70,45 @@ export const Content = () => {
     const containerHeight = containerRef.current.clientHeight
     bottomSpacerRef.current.style.height = `${scrollOffset + containerHeight}px`
   }, [scrollOffset, textElements.length])
+
+  useEffect(() => {
+    const handleKeyPress = (event: KeyboardEvent) => {
+      const maxIndex = textElements.length - 1;
+
+      if (event.code === "Escape") {
+        event.preventDefault();
+        dispatch(stopTeleprompter());
+      } else if (event.code === "Space") {
+        event.preventDefault();
+        if (status === "stopped") {
+          dispatch(startTeleprompter());
+        } else if (status === "started") {
+          dispatch(stopTeleprompter());
+        }
+      } else if (event.code === "ArrowUp") {
+        event.preventDefault();
+        dispatch(setFinalTranscriptIndex(Math.max(-1, finalTranscriptIndex - 15)));
+        dispatch(setInterimTranscriptIndex(Math.max(-1, interimTranscriptIndex - 15)));
+      } else if (event.code === "ArrowLeft") {
+        event.preventDefault();
+        dispatch(setFinalTranscriptIndex(Math.max(-1, finalTranscriptIndex - 5)));
+        dispatch(setInterimTranscriptIndex(Math.max(-1, interimTranscriptIndex - 5)));
+      } else if (event.code === "ArrowDown") {
+        event.preventDefault();
+        dispatch(setFinalTranscriptIndex(Math.min(maxIndex, finalTranscriptIndex + 15)));
+        dispatch(setInterimTranscriptIndex(Math.min(maxIndex, interimTranscriptIndex + 15)));
+      } else if (event.code === "ArrowRight") {
+        event.preventDefault();
+        dispatch(setFinalTranscriptIndex(Math.min(maxIndex, finalTranscriptIndex + 5)));
+        dispatch(setInterimTranscriptIndex(Math.min(maxIndex, interimTranscriptIndex + 5)));
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyPress);
+    return () => {
+      window.removeEventListener("keydown", handleKeyPress);
+    };
+  })
 
   return (
     <main className="content-area">


### PR DESCRIPTION
 This PR adds keyboard shortcut support to the teleprompter. Users can press Space to start/stop, Escape to stop, and arrow keys to jump forward or backward through the script (Up/Down by 15 words, Left/Right by 5 words). Shortcuts are automatically disabled in edit mode so they don't interfere with text input. The README has been updated to document the new shortcuts.  