### PR TITLE
Fixed issue with speech recogniser timing out during periods of silence

### DIFF
--- a/src/lib/speech-recognizer.ts
+++ b/src/lib/speech-recognizer.ts
@@ -6,6 +6,7 @@ type SubscriberFunction = (
 export default class SpeechRecognizer {
   private recognizer: SpeechRecognition
   private subscribers: SubscriberFunction[] = []
+  private shouldListen: Boolean = false
 
   constructor() {
     this.recognizer = new webkitSpeechRecognition()
@@ -33,13 +34,21 @@ export default class SpeechRecognizer {
         subscriber(final_transcript, interim_transcript)
       }
     }
+
+    this.recognizer.onend = () => {
+      if (this.shouldListen) {
+        this.recognizer.start()
+      }
+    }
   }
 
   start(): void {
+    this.shouldListen = true
     this.recognizer.start()
   }
 
   stop(): void {
+    this.shouldListen = false
     this.recognizer.stop()
   }
 


### PR DESCRIPTION
I was also experiencing the same issue as #6.

This appears to be a limitation of the speech recognition api where it will time out after a long period of silence.  Solution was to maintain a flag "shoudListen" which is set to true when the recognizer is started and is set to false when the recognizer is intentionally stopped.  If the recognizer stops but the shouldListen flag is set to true, we automatically restart the recognizer.