### PR TITLE
fix: prevent scroll jumping by syncing all transcript updates

### DIFF
--- a/src/features/content/Content.tsx
+++ b/src/features/content/Content.tsx
@@ -49,16 +49,16 @@ export const Content = () => {
       if (lastRef.current) {
         containerRef.current.scrollTo({
           top: Math.max(lastRef.current.offsetTop - scrollOffset, 0),
-          behavior: "smooth",
+          behavior: "auto",
         })
       } else {
         containerRef.current.scrollTo({
           top: 0,
-          behavior: "smooth",
+          behavior: "auto",
         })
       }
     }
-  })
+  }, [interimTranscriptIndex, finalTranscriptIndex, scrollOffset])
 
   useLayoutEffect(() => {
     if (!containerRef.current || !bottomSpacerRef.current) {


### PR DESCRIPTION
- Add finalTranscriptIndex to useEffect dependency array
- Change scroll behavior from smooth to auto for consistent updates
- Ensures scroll position updates whenever transcript indices change

Julien, thanks for the awesome utility! I was having trouble where after a few paragraphs of spoken text, it started jumping up and down a couple of lines making it really hard to track where I was. This fix made it go away. Hope it helps.